### PR TITLE
Dev gz

### DIFF
--- a/src/audio-engine/audio-engine.ts
+++ b/src/audio-engine/audio-engine.ts
@@ -5,7 +5,6 @@ import { filterSignals } from './envelope';
 
 
 
-
 const throwif = (condition: boolean, message: string) => {
   if(!condition) throw Error(message);
 }
@@ -21,6 +20,8 @@ export type FilteredSource = {
 
 //@ts-ignore
 const AudioContext = (window.AudioContext || window.webkitAudioContext);
+//@ts-ignore
+const OfflineAudioContext = (window.OfflineAudioContext || window.webkitOfflineAudioContext);
 
 export class AudioEngine {
   context: AudioContext

--- a/src/audio-engine/audio-engine.ts
+++ b/src/audio-engine/audio-engine.ts
@@ -40,6 +40,25 @@ export class AudioEngine {
   }
 
   /**
+   * Renders an offline audio context in a more browser agnostic way.
+   * neither Safari or Edge like `await context.startRendering()`
+   * @param context offline audio context
+   * @returns {Promise<AudioBuffer>} the rendered buffer
+   */
+  public async renderContextAsync(context: OfflineAudioContext): Promise<AudioBuffer> {
+    return new Promise((resolve, reject) => {
+      context.oncomplete = function(event: OfflineAudioCompletionEvent) {
+        if(!event.renderedBuffer){
+          reject("failed to get renderedBuffer after context completed rendering");
+        } else {
+          resolve(event.renderedBuffer);
+        }
+      };
+      context.startRendering();
+    });
+  }
+
+  /**
    * Creates a buffer source node filled with the supplied data
    * @param buffer The buffer of samples in a Float32Array
    * @param context audio context to use
@@ -47,8 +66,9 @@ export class AudioEngine {
    */
   public createBufferSource(buffer: Float32Array, context: AudioContext|OfflineAudioContext = this.context){
     const source = context.createBufferSource();
-    source.buffer = context.createBuffer(1, buffer.length, this.context.sampleRate) 
-    source.buffer.copyToChannel(buffer, 0);
+    source.buffer = context.createBuffer(1, buffer.length, this.context.sampleRate);
+    const sourceBuffer = source.buffer.getChannelData(0);
+    sourceBuffer.set(buffer, 0);
     return source;
   }
 
@@ -169,7 +189,7 @@ export class AudioEngine {
 
     merger.connect(offlineContext.destination);
     sources.forEach(source => source.source.start());
-    const impulseResponse = await offlineContext.startRendering();
+    const impulseResponse = await this.renderContextAsync(offlineContext);
     const blob = wavAsBlob([normalize(impulseResponse.getChannelData(0))], { sampleRate, bitDepth: 32 });
     saveAs(blob, "testFilters.wav");
 

--- a/src/compute/energy-decay.ts
+++ b/src/compute/energy-decay.ts
@@ -167,7 +167,7 @@ class EnergyDecay extends Solver{
                 filteredsource.gain.connect(offlineContext.destination);
                 filteredsource.source.start(); 
 
-                let data = await offlineContext.startRendering(); 
+                let data = await audioEngine.renderContextAsync(offlineContext);
                 self.filteredData.push(data.getChannelData(0)); 
             }
 

--- a/src/compute/raytracer/image-source/index.ts
+++ b/src/compute/raytracer/image-source/index.ts
@@ -732,7 +732,7 @@ export class ImageSourceSolver extends Solver {
         merger.connect(offlineContext.destination);
         sources.forEach(source=>source.source.start());
 
-        this.impulseResponse = await offlineContext.startRendering();
+        this.impulseResponse = await audioEngine.renderContextAsync(offlineContext);
 
         return this.impulseResponse;
 

--- a/src/compute/raytracer/index.ts
+++ b/src/compute/raytracer/index.ts
@@ -1775,8 +1775,6 @@ class RayTracer extends Solver {
           samples[f][roundedSample] += p[f];
       }
     }
-
-    const maxFrequency = frequencies.reduce((a,b)=>Math.max(a,b));
     
     //@ts-ignore
     samples = filterSignals(samples);
@@ -1794,45 +1792,17 @@ class RayTracer extends Solver {
       }
     }
 
-    // for(let i = 0; i<signal.length; i++){ 
-    //   signal[i]/=max;
-    // }
-    
 
-    console.log(signal);
-    // samples.forEach((x,i,arr)=>{
-    //   console.log(frequencies[i]/maxFrequency);
-    //   const low = ac.Flower(3, frequencies[i]) as number;
-    //   const high = ac.Fupper(3, frequencies[i]) as number;
-    //   const {b, a} = compute_bandpass_biquad_coefficients(low, high, sampleRate)
-    //   arr[i] = filter(b,a,x).map(val=>val*(frequencies[i]/maxFrequency)**2);
-    // });
 
     const offlineContext = audioEngine.createOfflineContext(1, signal.length, sampleRate);
 
-
-
-    // const sources = audioEngine.createFilteredSources(samples, frequencies, offlineContext); 
     const source = audioEngine.createBufferSource(normalize(signal), offlineContext)
-    
-    // const merger = audioEngine.createMerger(sources.length, offlineContext);
-    
-    // sources[0].gain.connect(offlineContext.destination);
-    // for(let i = 0; i<sources.length; i++){
-      // sources[i].gain.connect(merger, 0, i);
-      // sources[i].connect(merger, 0, i);
-    // }
 
     source.connect(offlineContext.destination);
     source.start();
-    // merger.connect(offlineContext.destination);
-    // for(let i = 0; i<sources.length; i++){
-      // sources[i].start();
-    // }
-    // sources.forEach(source=>source.source.start());
-    // sources.forEach(source=>source.start());
 
-    this.impulseResponse = await offlineContext.startRendering();
+
+    this.impulseResponse = await audioEngine.renderContextAsync(offlineContext);
     return this.impulseResponse;
   }
 


### PR DESCRIPTION
fix for #58

two things had to be changed:
1. `AudioBuffer` did not have a `copyToChannel` method, so the returned buffer in `AudioEngine.createBufferSource` had to be filled manually like so:

```ts
const sourceBuffer = source.buffer.getChannelData(0);
sourceBuffer.set(buffer, 0);
```

2. Apparently `OfflineAudioContext.startRendering()` does not return the rendered `AudioBuffer`, instead it can be pulled out of the event callback `OfflineAudioContext.oncomplete` like so:

```ts
context.oncomplete = function(event: OfflineAudioCompletionEvent) {
  if(!event.renderedBuffer){
    reject("failed to get renderedBuffer after context completed rendering");
  } else {
    resolve(event.renderedBuffer);
  }
};
context.startRendering();
```


see `AudioEngine.renderContextAsync` for implementation.